### PR TITLE
post_up and post_down commands

### DIFF
--- a/wireguard_client/rootfs/etc/cont-init.d/config.sh
+++ b/wireguard_client/rootfs/etc/cont-init.d/config.sh
@@ -64,8 +64,9 @@ dns=$(IFS=", "; echo "${listDns[*]}")
 echo "DNS = ${dns}" >> "${config}"
 
 # Post Up & Down defaults
-post_up="iptables -t nat -A POSTROUTING -o wg0 -j MASQUERADE"
-post_down="iptables -t nat -D POSTROUTING -o wg0 -j MASQUERADE"
+post_up="iptables -A FORWARD -i %i -j ACCEPT; iptables -A FORWARD -o %i -j ACCEPT; iptables -t nat -A POSTROUTING -o eth0 -j MASQUERADE"
+post_down="iptables -D FORWARD -i %i -j ACCEPT; iptables -D FORWARD -o %i -j ACCEPT; iptables -t nat -D POSTROUTING -o eth0 -j MASQUERADE"
+
 if [[ $(</proc/sys/net/ipv4/ip_forward) -eq 0 ]]; then
     bashio::log.warning
     bashio::log.warning "IP forwarding is disabled on the host system!"


### PR DESCRIPTION
# Proposed Changes

For POSTROUTING to work, MASQUERADE on main network interface have set, which is eth0 (at least on RPi). To use wireguard to access other nodes on same local network, forwarding on wg0 interface is set.

## Related Issues

https://github.com/bigmoby/addon-wireguard-client/issues/4
