### PR TITLE
WIP: Make dns, post_up and post_down optional

### DIFF
--- a/wireguard_client/rootfs/etc/cont-init.d/config.sh
+++ b/wireguard_client/rootfs/etc/cont-init.d/config.sh
@@ -50,17 +50,15 @@ else
 fi
 
 # Add all server DNS addresses to the configuration
-listDns=()
 if bashio::config.has_value "interface.dns"; then
+    listDns=()
     # Use allowed IP's defined by the user.
     for address in $(bashio::config "interface.dns"); do
         listDns+=("${address}")
     done
-else
-    bashio::exit.nok 'You need a dns configured'
+    dns=$(IFS=", "; echo "${listDns[*]}")
+    echo "DNS = ${dns}" >> "${config}"
 fi
-dns=$(IFS=", "; echo "${listDns[*]}")
-echo "DNS = ${dns}" >> "${config}"
 
 if [[ $(</proc/sys/net/ipv4/ip_forward) -eq 0 ]]; then
     bashio::log.warning

--- a/wireguard_client/rootfs/etc/cont-init.d/config.sh
+++ b/wireguard_client/rootfs/etc/cont-init.d/config.sh
@@ -76,17 +76,13 @@ fi
 
 # Post Up & Down defaults
 # Check if custom post_up value
-if ! bashio::config.has_value 'interface.post_up'; then
-    bashio::exit.nok 'post_up command is required'
-else
+if bashio::config.has_value 'interface.post_up'; then
     post_up=$(bashio::config 'interface.post_up')
     echo "PostUp = ${post_up}" >> "${config}"
 fi
 
 # Check if custom post_down value
-if ! bashio::config.has_value 'interface.post_down'; then
-    bashio::exit.nok 'post_down command is required'
-else
+if bashio::config.has_value 'interface.post_down'; then
     post_down=$(bashio::config 'interface.post_down')
     echo "PostDown = ${post_down}" >> "${config}"
 fi


### PR DESCRIPTION
# Proposed Changes

Like we discussed in #14. I have never worked with Home Assistant Addons before so I hope I got everything correct. My initial thought was to make `dns`, `post_up` and `post_down` optional via the schema, changing `str` to `str?` in [the schema](https://github.com/bigmoby/hassio-repository-addon/blob/main/wireguard-client/config.json#L61) but that just used the default value from options instead. I changed approach to just allow an empty value instead.

## DNS
Set the dns list to an empty list, `dns: []`, this will remove `DNS = ...` from `wg0.conf`

## PostUP and PostDown
Set the post_up (or post_down) to an empty string, `post_up: ""`, this will remove `PostUp = ...` from `wg0.conf`

## Related Issues
* #14

---

What do you think? An alternative would to use `str?` and remove the default values for `dns`, `post_up` and `post_down` from options. That should not break existing installations, but will change the behavior a little. What do you prefer?