### PR TITLE
WIP: Optional values "the other way" and replace peer with peers

### DIFF
--- a/wireguard_client/config.json
+++ b/wireguard_client/config.json
@@ -40,15 +40,12 @@
          "post_up": "iptables -t nat -A POSTROUTING -o wg0 -j MASQUERADE",
          "post_down": "iptables -t nat -D POSTROUTING -o wg0 -j MASQUERADE"
       },
-      "peer":{
+      "peers":[{
          "public_key": "",
          "pre_shared_key": "",
          "endpoint": "xxxxxx.duckdns.com",
-         "allowed_ips":[
-            "10.6.0.0/24"
-         ],
-         "persistent_keep_alive": "25"
-      }
+         "allowed_ips":["10.6.0.0/24"]
+      }]
    },
    "schema":{
       "log_level":"list(trace|debug|info|notice|warning|error|fatal)?",
@@ -61,7 +58,7 @@
          "post_up": "str",
          "post_down": "str"
       },
-      "peer":{
+      "peers": [{
          "public_key":"str?",
          "pre_shared_key":"str?",
          "endpoint":"str",

--- a/wireguard_client/config.json
+++ b/wireguard_client/config.json
@@ -31,14 +31,8 @@
    ],
    "options":{
       "interface":{
-         "private_key": "password?",
-         "address": "10.6.0.2",
-         "dns":[
-            "8.8.8.8",
-            "8.8.4.4"
-         ],
-         "post_up": "iptables -t nat -A POSTROUTING -o wg0 -j MASQUERADE",
-         "post_down": "iptables -t nat -D POSTROUTING -o wg0 -j MASQUERADE"
+         "private_key": "private-key-here",
+         "address": "10.6.0.2"
       },
       "peers":[{
          "public_key": "",
@@ -53,10 +47,10 @@
          "private_key": "password?",
          "address": "str",
          "dns":[
-            "str"
+            "str?"
          ],
-         "post_up": "str",
-         "post_down": "str"
+         "post_up": "str?",
+         "post_down": "str?"
       },
       "peers": [{
          "public_key":"str?",
@@ -65,8 +59,8 @@
          "allowed_ips":[
             "str"
          ],
-         "persistent_keep_alive":"int"
-      }
+         "persistent_keep_alive":"int?"
+      }]
    },
    "image": "bigmoby/{arch}-addon-wireguard-client"
  }

--- a/wireguard_client/rootfs/etc/cont-init.d/config.sh
+++ b/wireguard_client/rootfs/etc/cont-init.d/config.sh
@@ -50,17 +50,15 @@ else
 fi
 
 # Add all server DNS addresses to the configuration
-listDns=()
 if bashio::config.has_value "interface.dns"; then
+    listDns=()
     # Use allowed IP's defined by the user.
     for address in $(bashio::config "interface.dns"); do
         listDns+=("${address}")
     done
-else
-    bashio::exit.nok 'You need a dns configured'
+    dns=$(IFS=", "; echo "${listDns[*]}")
+    echo "DNS = ${dns}" >> "${config}"
 fi
-dns=$(IFS=", "; echo "${listDns[*]}")
-echo "DNS = ${dns}" >> "${config}"
 
 if [[ $(</proc/sys/net/ipv4/ip_forward) -eq 0 ]]; then
     bashio::log.warning

--- a/wireguard_client/rootfs/etc/cont-init.d/config.sh
+++ b/wireguard_client/rootfs/etc/cont-init.d/config.sh
@@ -76,17 +76,13 @@ fi
 
 # Post Up & Down defaults
 # Check if custom post_up value
-if ! bashio::config.has_value 'interface.post_up'; then
-    bashio::exit.nok 'post_up command is required'
-else
+if bashio::config.has_value 'interface.post_up'; then
     post_up=$(bashio::config 'interface.post_up')
     echo "PostUp = ${post_up}" >> "${config}"
 fi
 
 # Check if custom post_down value
-if ! bashio::config.has_value 'interface.post_down'; then
-    bashio::exit.nok 'post_down command is required'
-else
+if bashio::config.has_value 'interface.post_down'; then
     post_down=$(bashio::config 'interface.post_down')
     echo "PostDown = ${post_down}" >> "${config}"
 fi


### PR DESCRIPTION
# Proposed Changes

This commit is based on top of #15, I do not think this PR should be merged as-is, this is a breaking change that would break peoples installations. It implements the discussion in #14 and re-implements #15 in another way.

## Peers
If you like to go forward with this, or something similar I think we need to do one of 3 things:

a) Make it a breaking change, clearly communicate this to the users, or
b) Make some form of migration script that rewrites the configuration to the new format, or
c) Support both `peer` and `peers`

I initially tried to implement c, but it quickly got messy. I considered b as a better solution. In this PR i just did a :)

```
peers:
  - public_key: pUBlickey=
    pre_shared_key: ''
    endpoint: myserver.example.com:1234
    allowed_ips:
      - 10.0.0.0/24
    persistent_keep_alive: '25'
```
This is exactly the same syntax, just a list of possible multiple peers. You can inspect the commit that adds this functionality here: https://github.com/nsg/addon-wireguard-client/commit/698b4d3a7daebd74cbb621b92ace5f62e502e913

A few notes:
* Not sure if it's good to use internals like this https://github.com/nsg/addon-wireguard-client/commit/698b4d3a7daebd74cbb621b92ace5f62e502e913#diff-f5eeb82cf2a7d038d1baaace560daa12ee3d2ded417fc0f2d6d45278566ab68dR106
* I hope `bashio::jq` is a stable API to use https://github.com/nsg/addon-wireguard-client/commit/698b4d3a7daebd74cbb621b92ace5f62e502e913#diff-f5eeb82cf2a7d038d1baaace560daa12ee3d2ded417fc0f2d6d45278566ab68dR122 .. I found no other nice way to access the data from the loop otherwise.

## Optional values "the other way"

This is the alternative implementation of #15, instead of messing with empty variables this just makes the values optional via the built in functionality. This feels more like "The Home Assistant Way" but has the disadvantage that we wont get a nice sample configuration generated on first install. This change should be backward compatible.

See the commit here: https://github.com/nsg/addon-wireguard-client/commit/414f2f920c4a5000609262ff3e56edcf79ac6e9d

## To summarize

Feel free to close this, see this more as a PR with code samples and ideas ... I think https://github.com/nsg/addon-wireguard-client/commit/414f2f920c4a5000609262ff3e56edcf79ac6e9d could be an interesting alternative to #15 for example. If you feel you like to move forward with the idea of supporting multiple peers I would love to discuss what you think about the options a, b or c.

Oh, this code is not that well tested, it runs (for me) :grin: 

## Related Issues / PRs

* #15 
* #14