### PR TITLE
fixed json formatting for api

### DIFF
--- a/wireguard_client/rootfs/etc/services.d/api/run
+++ b/wireguard_client/rootfs/etc/services.d/api/run
@@ -27,12 +27,12 @@ while true; do
             transfer_tx="${line[7]}"
 
             peer=$(bashio::var.json \
-                    'endpoint' "^${endpoint}" \
-                    'latest_handshake' "^${latest_handshake}" \
+                    'endpoint' "${endpoint}" \
+                    'latest_handshake' "${latest_handshake}" \
                     'transfer_rx' "^${transfer_rx}" \
                     'transfer_tx' "^${transfer_tx}")
 
-            peers+=("peer_${count}" "${peer}")
+            peers+=("peer_${count}" "^${peer}")
             (( count++ ))
         fi
     done <<< "$(wg show all dump)"


### PR DESCRIPTION
# Proposed Changes

> Removed caret on endpoint and handshake variables to have them formatted as text. Added caret to peer to ensure it is formatted as a json dictionary and not a string 

## Related Issues

> [([Github link][autolink-references] to related issues or pull requests)](https://github.com/bigmoby/addon-wireguard-client/issues/27)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/