### PR TITLE
Comply with the log level setting when logging the current WireGuard …

### DIFF
--- a/wireguard_client/rootfs/etc/services.d/status/run
+++ b/wireguard_client/rootfs/etc/services.d/status/run
@@ -5,4 +5,6 @@
 # ==============================================================================
 sleep 30
 bashio::log.info "Requesting current status from WireGuard Client..."
-exec wg show
+if [[ "${__BASHIO_LOG_LEVEL}" -ge "${__BASHIO_LOG_LEVEL_INFO}" ]]; then
+    exec wg show
+fi


### PR DESCRIPTION
This proposed change has been tested by running the modified script manually inside the add-on container but not via the build chain or service infrastructure.

# Proposed Changes

> Make status logging comply with the configured log level by logging WireGuard status details (i.e. `wg show` output) only when the configured log level is INFO or higher (matching the existing log level of the leading message). Does not change the default behavior.
>
> Rationale: While minimizing disk wear and tracking unnecessary IO I noticed that the WireGuard client add-on keeps writing the current status to logs every 30s even when configured to log only warnings or errors.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/