### PR TITLE
Clarify how AllowedIPs are used

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ This add-on is not compatible with a catch-all value for allowed_ips, like 0.0.0
   sysctl: error setting key 'net.ipv4.conf.all.src_valid_mark': Read-only file system
 ```
 
-it's because you are trying to give access from every ip in the planet. Simply use single ips or ip classes that need to be connected. If you don't own a static ip address you can consider a VPN.
+it's because you are trying to create routes to/from every possible IP through the WireGuard interface. Simply use single ips or ip classes that need to be connected. If you don't own a static ip address you can consider a VPN.
 
 ## Contributing
 


### PR DESCRIPTION
# Proposed Changes

What the `AllowedIPs` property actually does could use additional clarification. Since this is a WG client rather than WG server, I believe most users will care that this value specifies what traffic routes through the wireguard network.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/